### PR TITLE
makeModulesClosure: include /lib/firmware/edid

### DIFF
--- a/pkgs/build-support/kernel/compress-firmware-xz.nix
+++ b/pkgs/build-support/kernel/compress-firmware-xz.nix
@@ -7,14 +7,18 @@ let
 in
 
 runCommand "${firmware.name}-xz" args ''
+  edids=(-path 'lib/firmware/edid/*')
   mkdir -p $out/lib
   (cd ${firmware} && find lib/firmware -type d -print0) |
-      (cd $out && xargs -0 mkdir -v --)
-  (cd ${firmware} && find lib/firmware -type f -print0) |
+      (cd $out && xargs -0 mkdir -pv --)
+  (cd ${firmware} && find lib/firmware -type f -not "''${edids[@]}" -print0) |
       (cd $out && xargs -0rtP "$NIX_BUILD_CORES" -n1 \
           sh -c 'xz -9c -T1 -C crc32 --lzma2=dict=2MiB "${firmware}/$1" > "$1.xz"' --)
-  (cd ${firmware} && find lib/firmware -type l) | while read link; do
+  (cd ${firmware} && find lib/firmware -type l -not "''${edids[@]}") | while read link; do
       target="$(readlink "${firmware}/$link")"
       ln -vs -- "''${target/^${firmware}/$out}.xz" "$out/$link.xz"
   done
+  (cd ${firmware} && find lib/firmware -type f "''${edids[@]}" -print0) |
+      (cd $out && xargs -0rtP "$NIX_BUILD_CORES" -n1 \
+          sh -c 'ln -vs -- "${firmware}/$1" "$out/$1"' --)
 ''

--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -89,8 +89,8 @@ for module in $(< ~-/closure); do
     done || :
 done
 
-if test -d "edid" ; then
-    cp -v --parents lib/firmware/edid "$out" 2>/dev/null
+if test -e "edid" ; then
+    cp -v --parents --no-preserve=mode lib/firmware/edid "$out" 2>/dev/null
 fi
 
 # copy module ordering hints for depmod

--- a/pkgs/tools/misc/edid-generator/default.nix
+++ b/pkgs/tools/misc/edid-generator/default.nix
@@ -21,9 +21,6 @@ stdenv.mkDerivation {
   pname = "edid-generator";
   version = "master-2023-11-20";
 
-  # so `hardware.firmware` doesn't compress it
-  compressFirmware = false;
-
   src = fetchFromGitHub {
     owner = "akatrevorjay";
     repo = "edid-generator";


### PR DESCRIPTION
this allows us not to pass `compressFirmware = false;`
 inside EDID derivations as this mechanic very tricky to discover.

related to #279789

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
